### PR TITLE
fix(lint): comment out the now-unused datesunique assignment

### DIFF
--- a/pyvoa/geopd_builder.py
+++ b/pyvoa/geopd_builder.py
@@ -360,7 +360,7 @@ class GPDBuilder:
        kwargs['when']=[when_beg_data.strftime("%d/%m/%Y")+':'+when_end_data.strftime("%d/%m/%Y")]
 
        bypopvalue = None
-       datesunique = list(input.date.unique())
+       #datesunique = list(input.date.unique())
 
        prefix = ['date', 'where']
        suffix = ['code','geometry']


### PR DESCRIPTION
The `lint` job has been red on `main` since 9492bf9:

```
pyvoa/geopd_builder.py:363:8: F841 Local variable `datesunique` is assigned to but never used
```

That commit removed the `len(datesunique)` line, which was the only reader of the binding. Commented out rather than deleted, per the convention recorded in `CLAUDE.md` ("dead assignments are commented out rather than deleted, so the original intent stays readable").

`ruff check .` is clean again and the 176 offline tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)