### PR TITLE
feat(ci): declare and test Python 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
     steps:
       - uses: actions/checkout@v4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Unreleased
+- Python 3.13 is declared as supported and added to the CI test matrix, which
+  now covers 3.10, 3.11, 3.12 and 3.13.
 - fix: the four `GeoInfo` tests built a real `GeoInfo(0)`, which builds a
   `GeoManager` and downloads about ten pages, so they failed on CI and passed
   locally only on a warm cache. They now use `GeoInfo.__new__`, like the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ Dead assignments are commented out rather than deleted, so the original intent s
 `.github/workflows/ci.yml` runs three jobs on push to `main` and on every pull request:
 
 - `lint` — pinned ruff, installed alone so the job does not build geopandas.
-- `test` — python 3.10/3.11/3.12 (matching the classifiers), the offline suite, coverage written to the GitHub Actions job summary and uploaded as a `coverage.xml` artefact. There is no third-party coverage service, hence a CI badge in `README.md` but no coverage badge.
+- `test` — python 3.10/3.11/3.12/3.13 (matching the classifiers), the offline suite, coverage written to the GitHub Actions job summary and uploaded as a `coverage.xml` artefact. There is no third-party coverage service, hence a CI badge in `README.md` but no coverage badge.
 - `network` — the `@pytest.mark.network` tests, restricted to the weekly cron and manual dispatch, so an upstream outage can never block a pull request.
 
 ## Architecture

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]


### PR DESCRIPTION
Adds the `Programming Language :: Python :: 3.13` trove classifier and extends the CI test matrix to `3.10 / 3.11 / 3.12 / 3.13`. `requires-python = ">=3.10"` is unchanged, and the single-version `lint` and `network` jobs stay on 3.12.

`CHANGELOG.md` (Unreleased) and the CI section of `CLAUDE.md` are updated to match.

**Verification.** The suite has not been run on 3.13 locally (only 3.12 is installed here), so this PR's own `pytest (python 3.13)` job is the first real run. What was checked is that the dependency tree resolves there: `pip download --only-binary=:all: --python-version 3.13` succeeds for the full runtime and `dev` sets including transitives — pandas 3.0.5, numpy 2.5.2, shapely 2.1.2, lxml 6.1.1, geopandas 1.1.4, contextily, pycountry_convert, IPython, pytest, pytest-cov. No `sys.version_info` branching exists in `pyvoa/`.

Note, not caused by this PR: dependencies are unpinned, so CI now installs pandas 3.0.x on every matrix entry, not just 3.13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)